### PR TITLE
Change from ws to irc

### DIFF
--- a/botardo.js
+++ b/botardo.js
@@ -15,8 +15,8 @@ opts = {
         debug: false
     },
     connection: {
-        port: 80,
         server: 'irc.chat.twitch.tv',
+        port: 6697,
         reconnect: true
     },
     identity: {


### PR DESCRIPTION
- Changed to standard IRC (ws isnt needed for bots)
- Changed to a secure port (for obvious reasons)