### PR TITLE
Revert server, port and secure config options

### DIFF
--- a/botardo.js
+++ b/botardo.js
@@ -15,10 +15,7 @@ opts = {
         debug: false
     },
     connection: {
-        server: 'irc.chat.twitch.tv',
-        port: 6697,
-        reconnect: true,
-        secure: true
+        reconnect: true
     },
     identity: {
       username: "vjbotardo",


### PR DESCRIPTION
They stopped the bot from working, so I'll revert and leave as is

To note, the default options will connect to ws securely, which is still fine.