### PR TITLE
Bump all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "event-stream": "^4.0.1",
     "fs": "^0.0.1-security",
     "gif-frames": "^1.0.1",
-    "mocha": "^8.2.1",
+    "mocha": "^8.3.0",
     "node-fetch": "^2.6.1",
     "node-gyp": "^7.1.2",
-    "node-schedule": "^1.3.2",
+    "node-schedule": "^2.0.0",
     "request": "^2.88.2",
     "rewire": "^5.0.0",
-    "sqlite3": "^4.1.1",
+    "sqlite3": "^5.0.1",
     "tmi.js": "^1.7.1"
   },
   "scripts": {


### PR DESCRIPTION
There was a breaking change in `node-schedule`:

- Remove support for job objects. See [UPGRADING.md](https://github.com/node-schedule/node-schedule/pull/557/files#diff-f411a5009131db5a6c7242b49ca78488f2d274ef9e5e5f4de9262a42108a5386) for more details.

I'm not 100% sure how to fix it, can you pls check